### PR TITLE
URL Cleanup

### DIFF
--- a/README
+++ b/README
@@ -3,15 +3,15 @@
 
 This is a normal RabbitMQ plugin. For detailed installation instructions
 go to:
-        http://www.rabbitmq.com/admin-guide.html#installing-plugins
+        https://www.rabbitmq.com/admin-guide.html#installing-plugins
 
 A summary:
 
-    hg clone http://hg.rabbitmq.com/rabbitmq-public-umbrella/
+    hg clone https://hg.rabbitmq.com/rabbitmq-public-umbrella/
     cd rabbitmq-public-umbrella
     make co
     make 
-    hg clone http://hg.rabbitmq.com/rabbitmq-status/
+    hg clone https://hg.rabbitmq.com/rabbitmq-status/
     cd rabbitmq-status
     make
 

--- a/erltl/src/erltl.erl
+++ b/erltl/src/erltl.erl
@@ -1,4 +1,4 @@
-%% @author Yariv Sadan <yarivsblog@gmail.com> [http://yarivsblog.com]
+%% @author Yariv Sadan <yarivsblog@gmail.com> [https://yarivsblog.com]
 %% @version 0.9.3
 %% @copyright Yariv Sadan 2006-2007
 %%
@@ -139,7 +139,7 @@
 %% SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -module(erltl).
--author("Yariv Sadan (yarivsblog@gmail.com, http://yarivsblog.com)").
+-author("Yariv Sadan (yarivsblog@gmail.com, https://yarivsblog.com)").
 -export([compile/1, compile/2, forms_for_file/1, 
 	 forms_for_file/2, forms_for_data/2, forms_for_data/3]).
 

--- a/src/rabbit_status.erl
+++ b/src/rabbit_status.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/rabbit_status_app.erl
+++ b/src/rabbit_status_app.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/rabbit_status_sup.erl
+++ b/src/rabbit_status_sup.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/rabbit_status_web.erl
+++ b/src/rabbit_status_web.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/status_render.erl
+++ b/src/status_render.erl
@@ -1,7 +1,7 @@
 %%   The contents of this file are subject to the Mozilla Public License
 %%   Version 1.1 (the "License"); you may not use this file except in
 %%   compliance with the License. You may obtain a copy of the License at
-%%   http://www.mozilla.org/MPL/
+%%   https://www.mozilla.org/MPL/
 %%
 %%   Software distributed under the License is distributed on an "AS IS"
 %%   basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/src/template.et
+++ b/src/template.et
@@ -4,7 +4,7 @@
     FdUsed, FdTotal, FdWarn,
     MemUsed, MemTotal, MemWarn, MemEts, MemBinary]
       = Data  %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" dir="ltr">
 <head>
 <!-- Design copied from HAProxy status page -->


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://erlang.org/doc/doc-5.5.1/lib/compiler-4.4.1/doc/html/compile.html (404) with 1 occurrences could not be migrated:  
   ([https](https://erlang.org/doc/doc-5.5.1/lib/compiler-4.4.1/doc/html/compile.html) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd) result ReadTimeoutException).
* http://hg.rabbitmq.com/rabbitmq-public-umbrella/ (UnknownHostException) with 1 occurrences migrated to:  
  https://hg.rabbitmq.com/rabbitmq-public-umbrella/ ([https](https://hg.rabbitmq.com/rabbitmq-public-umbrella/) result UnknownHostException).
* http://hg.rabbitmq.com/rabbitmq-status/ (UnknownHostException) with 1 occurrences migrated to:  
  https://hg.rabbitmq.com/rabbitmq-status/ ([https](https://hg.rabbitmq.com/rabbitmq-status/) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.rabbitmq.com/admin-guide.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/admin-guide.html ([https](https://www.rabbitmq.com/admin-guide.html) result 200).
* http://yarivsblog.com with 2 occurrences migrated to:  
  https://yarivsblog.com ([https](https://yarivsblog.com) result 200).
* http://www.mozilla.org/MPL/ with 5 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).

# Ignored
These URLs were intentionally ignored.

* http://www.w3.org/1999/xhtml with 1 occurrences